### PR TITLE
API: Add camera events upload

### DIFF
--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -5,11 +5,20 @@ info:
 servers:
   - url: https://ivory-beam.example/beta
 paths:
-  /cameras/events:
+  /cameras/{id}/events:
     post:
       summary: Capture single camera event from authenticated camera
       security:
-        - jwtAuth: []
+        - deviceId: []
+          apikey: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+          description: Camera ID
       requestBody:
         required: true
         content:
@@ -20,14 +29,23 @@ paths:
         201:
           description: Event saved.
         401:
-          $ref: '#/components/responses/UnauthorizedError'
+          $ref: '#/components/responses/KeyUnauthorizedError'
         500:
           description: Internal server error. Event not saved.
-  /cameras/events/batch:
+  /cameras/{id}/events/batch:
     post:
       summary: Log batch of camera events from authenticated camera
       security:
-        - jwtAuth: []
+        - deviceId: []
+          apikey: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+          description: Camera ID
       requestBody:
         required: true
         content:
@@ -38,7 +56,7 @@ paths:
         201:
           description: All log entries were created
         401:
-          $ref: '#/components/responses/UnauthorizedError'
+          $ref: '#/components/responses/KeyUnauthorizedError'
         500:
           description: Internal server error. No events saved.
   /cafeterias:
@@ -82,10 +100,14 @@ paths:
                 $ref: "#/components/schemas/Error"
 components:
   securitySchemes:
-    jwtAuth:
-      type: http
-      scheme: bearer
-      bearerFormat: JWT
+    deviceId:
+      type: apiKey
+      in: header
+      name: X-DEVICE-ID
+    apiKey:
+      type: apiKey
+      in: header
+      name: X-API-KEY
   schemas:
     ObjectId:
       required:
@@ -180,5 +202,5 @@ components:
         message:
           type: string
   responses:
-    UnauthorizedError:
-      description: Access token is missing or invalid
+    KeyUnauthorizedError:
+      description: API key is missing or invalid

--- a/specs/api.yaml
+++ b/specs/api.yaml
@@ -3,8 +3,44 @@ info:
   version: 0.0.0
   title: ivory-beam API
 servers:
-  - url: http://ivory-beam.example/beta
+  - url: https://ivory-beam.example/beta
 paths:
+  /cameras/events:
+    post:
+      summary: Capture single camera event from authenticated camera
+      security:
+        - jwtAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CameraEvent"
+      responses:
+        201:
+          description: Event saved.
+        401:
+          $ref: '#/components/responses/UnauthorizedError'
+        500:
+          description: Internal server error. Event not saved.
+  /cameras/events/batch:
+    post:
+      summary: Log batch of camera events from authenticated camera
+      security:
+        - jwtAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CameraEventArray"
+      responses:
+        201:
+          description: All log entries were created
+        401:
+          $ref: '#/components/responses/UnauthorizedError'
+        500:
+          description: Internal server error. No events saved.
   /cafeterias:
     get:
       summary: List all cafeterias
@@ -45,6 +81,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 components:
+  securitySchemes:
+    jwtAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
   schemas:
     ObjectId:
       required:
@@ -54,6 +95,46 @@ components:
           type: integer
           format: int32
           minimum: 1
+    Timestamp:
+      description: Timestamp with RFC 3339 datetime.
+      required:
+        - timestamp
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+      example:
+        timestamp: "2017-07-21T17:32:28Z"
+    CameraEventType:
+      required:
+        - event_type
+      properties:
+        event_type:
+          type: string
+          enum:
+            - monitoring_started
+            - monitoring_ended
+            - person_entered
+            - person_left
+      example:
+        event_type: "person_entered"
+    CameraEvent:
+      allOf:
+          - $ref: "#/components/schemas/CameraEventType"
+          - $ref: "#/components/schemas/Timestamp"
+    CameraEventArray:
+      type: array
+      items:
+        $ref: "#/components/schemas/CameraEvent"
+      example:
+        - event_type: "monitoring_started"
+          timestamp: "2017-07-21T17:32:28Z"
+        - event_type: "person_entered"
+          timestamp: "2017-07-21T17:32:56Z"
+        - event_type: "person_entered"
+          timestamp: "2017-07-21T17:33:10Z"
+        - event_type: "person_left"
+          timestamp: "2017-07-21T17:33:40Z"
     CafeteriaPublicProperties:
       required:
         - name
@@ -98,3 +179,6 @@ components:
           format: int32
         message:
           type: string
+  responses:
+    UnauthorizedError:
+      description: Access token is missing or invalid


### PR DESCRIPTION
Creating a draft PR to discuss and resolve #18. Could you take a look @Rhantolq?

In this change to send events camera has to authenticate and [pass JWT tokens](https://swagger.io/docs/specification/authentication/bearer-authentication/) along the request. This way server knows which camera tries to save logs from logged in user name (here camera name).

Pros:
* Free authentication if we use JWT addon for Django REST Framework

Cons:
* We will have to ensure camera names are different than user names (let's say `camera-xxx` is reserved for cameras), which is sooo ugly.
* This format prevents adding intermediary steps. Imagine cafeteria needs to add some extra step before calling `/cameras/events/batch` from a different device. They can't do this.

Other option would be to authenticate [via keys](https://swagger.io/docs/specification/authentication/api-keys/). Basically we call `/cameras/{id}/events/batch` and send events there putting device ID and API key in headers. Also, this is also what big companies like Facebook use to authenticate apps to their service, and I feel this may suit IOT devices better.

Pros:
* No need to set up JWT Django addon for now 😊
* We can expose logging to different devices

Cons:
* Extra DB call to verify ID-key pair

@Rhantolq your opinion?
